### PR TITLE
updated wrtc version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "author": "vmolsa <ville.molsa@gmail.com> (http://github.com/vmolsa)",
   "dependencies": {
     "underscore": "^1.8.2",
-    "wrtc": "^0.0.49"
+    "wrtc": "0.0.65"
   }
 }


### PR DESCRIPTION
Hi. 
I updated the wrtc package version, 0.0.49 doesn't build (Ubuntu, >= node 4.x) anymore because of reasons, 0.0.65 does, and the increment is patch level only.